### PR TITLE
feat: add cross-platform app icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>AutoMancer</title>
+  <link rel="icon" type="image/png" href="images/AutoMancer.png" />
   <style>
     :root {
       color-scheme: dark;

--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
       -webkit-app-region: drag;
       font-weight: 500;
     }
+    header img {
+      height: 20px;
+      margin-right: 8px;
+    }
     main {
       padding: 16px 24px 24px;
       display: grid;
@@ -193,7 +197,7 @@
   </style>
 </head>
 <body>
-  <header>AutoMancer</header>
+  <header><img src="images/AutoMancer.png" alt="AutoMancer logo" />AutoMancer</header>
   <main>
     <section class="card">
       <h2><span class="icon">🖱️</span>Auto Clicker</h2>

--- a/main.js
+++ b/main.js
@@ -208,14 +208,15 @@ function createWindow() {
     'images',
     isMac ? 'AutoMancer.icns' : isWin ? 'AutoMancer.ico' : 'AutoMancer.png'
   );
+  const icon = nativeImage.createFromPath(iconPath);
   if (isMac) {
-    app.dock.setIcon(nativeImage.createFromPath(iconPath));
+    app.dock.setIcon(icon);
   }
   const WindowClass = isWin ? MicaBrowserWindow : BrowserWindow;
   win = new WindowClass({
     width: 640,
     height: 360,
-    icon: iconPath,
+    icon,
     titleBarStyle: 'hidden',
     titleBarOverlay: { color: '#00000000', symbolColor: '#ffffff' },
     autoHideMenuBar: true,
@@ -229,6 +230,9 @@ function createWindow() {
       nodeIntegration: false
     }
   });
+  if (typeof win.setIcon === 'function') {
+    win.setIcon(icon);
+  }
 
   win.loadFile(path.join(__dirname, 'index.html'));
   win.once('ready-to-show', () => {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, ipcMain, globalShortcut, BrowserWindow, screen } = require('electron');
+const { app, ipcMain, globalShortcut, BrowserWindow, screen, nativeImage } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { MicaBrowserWindow } = require('mica-electron');
@@ -203,10 +203,19 @@ function registerKeyHotkey(accelerator) {
 function createWindow() {
   const isWin = process.platform === 'win32';
   const isMac = process.platform === 'darwin';
+  const iconPath = path.join(
+    __dirname,
+    'images',
+    isMac ? 'AutoMancer.icns' : isWin ? 'AutoMancer.ico' : 'AutoMancer.png'
+  );
+  if (isMac) {
+    app.dock.setIcon(nativeImage.createFromPath(iconPath));
+  }
   const WindowClass = isWin ? MicaBrowserWindow : BrowserWindow;
-    win = new WindowClass({
-      width: 640,
-      height: 360,
+  win = new WindowClass({
+    width: 640,
+    height: 360,
+    icon: iconPath,
     titleBarStyle: 'hidden',
     titleBarOverlay: { color: '#00000000', symbolColor: '#ffffff' },
     autoHideMenuBar: true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "package": "electron-packager . AutoMancer --platform=win32 --arch=x64 --out=dist --overwrite",
+    "package:win": "electron-packager . AutoMancer --platform=win32 --arch=x64 --icon=images/AutoMancer.ico --out=dist --overwrite",
+    "package:mac": "electron-packager . AutoMancer --platform=darwin --arch=x64 --icon=images/AutoMancer.icns --out=dist --overwrite",
+    "package": "npm run package:win && npm run package:mac",
     "test": "echo \"No tests specified\""
   },
   "dependencies": {

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,9 @@
 const keySelect = document.getElementById('key');
+const header = document.querySelector('header');
 if (window.env && window.env.platform === 'darwin') {
-  document.querySelector('header').style.paddingLeft = '80px';
+  header.style.justifyContent = 'flex-end';
+} else {
+  header.style.justifyContent = 'flex-start';
 }
 const keys = [
   'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',


### PR DESCRIPTION
## Summary
- load platform-specific app icons and display window logo
- include logo image in the title bar
- add packaging scripts for Windows and macOS icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4385634c832f9f5a55454a5dd665