### PR TITLE
style: round corners on Windows and UI elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,10 @@
     }
     .card {
       backdrop-filter: blur(20px);
+      background: var(--bg);
       border: 2px solid transparent;
+      border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
       border-radius: 16px;
-      background:
-        linear-gradient(var(--bg), var(--bg)) padding-box,
-        linear-gradient(to bottom right, #D33818, #8c5cf3) border-box;
       padding: 16px;
       display: flex;
       flex-direction: column;
@@ -164,16 +163,9 @@
     }
     .actions button {
       width: var(--field-width);
-      border-radius: 0;
+      border-radius: 8px;
       border: 2px solid transparent;
-      --btn-bg: rgba(255, 255, 255, 0.07);
-      background:
-        linear-gradient(var(--btn-bg), var(--btn-bg)) padding-box,
-        linear-gradient(to bottom right, #D33818, #8c5cf3) border-box;
-      transition: background 0.2s;
-    }
-    .actions button:hover {
-      --btn-bg: var(--hover);
+      border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
     }
     button {
       flex: 0 0 auto;
@@ -191,7 +183,7 @@
     button.running {
       background-color: #7f1d1d;
       border-color: #dc2626;
-      background-image: none;
+      border-image: none;
     }
     button.running:hover {
       background-color: #991b1b;

--- a/index.html
+++ b/index.html
@@ -52,10 +52,12 @@
       box-sizing: border-box;
     }
     .card {
-      background: var(--bg);
       backdrop-filter: blur(20px);
-      border: 1px solid var(--border);
+      border: 2px solid transparent;
       border-radius: 16px;
+      background:
+        linear-gradient(var(--bg), var(--bg)) padding-box,
+        linear-gradient(to bottom right, #D33818, #8c5cf3) border-box;
       padding: 16px;
       display: flex;
       flex-direction: column;
@@ -162,27 +164,37 @@
     }
     .actions button {
       width: var(--field-width);
-      border-radius: 12px !important;
+      border-radius: 0;
+      border: 2px solid transparent;
+      --btn-bg: rgba(255, 255, 255, 0.07);
+      background:
+        linear-gradient(var(--btn-bg), var(--btn-bg)) padding-box,
+        linear-gradient(to bottom right, #D33818, #8c5cf3) border-box;
+      transition: background 0.2s;
+    }
+    .actions button:hover {
+      --btn-bg: var(--hover);
     }
     button {
       flex: 0 0 auto;
-      background: rgba(255, 255, 255, 0.07);
+      background-color: rgba(255, 255, 255, 0.07);
       border: 1px solid var(--border);
       border-radius: 6px;
       padding: 6px 12px;
       color: #fff;
       cursor: pointer;
-      transition: background 0.2s;
+      transition: background-color 0.2s;
     }
     button:hover {
-      background: var(--hover);
+      background-color: var(--hover);
     }
     button.running {
-      background: #7f1d1d;
+      background-color: #7f1d1d;
       border-color: #dc2626;
+      background-image: none;
     }
     button.running:hover {
-      background: #991b1b;
+      background-color: #991b1b;
     }
     .modal {
       position: fixed;

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
       user-select: none;
     }
 
+    html, body {
+      height: 100%;
+    }
+
       html.win32, body.win32 {
         border-radius: 12px;
         overflow: hidden;
@@ -50,8 +54,7 @@
     .card {
       background: var(--bg);
       backdrop-filter: blur(20px);
-      border: 2px solid transparent;
-      border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
+      border: 1px solid var(--border);
       border-radius: 16px;
       padding: 16px;
       display: flex;
@@ -159,9 +162,7 @@
     }
     .actions button {
       width: var(--field-width);
-      border: 2px solid transparent;
-      border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
-      border-radius:  12px !important;
+      border-radius: 12px !important;
     }
     button {
       flex: 0 0 auto;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
       background: rgba(0, 0, 0, 0.01);
       user-select: none;
     }
+
+    body.win32 {
+      border-radius: 12px;
+      overflow: hidden;
+    }
     header {
       height: 32px;
       padding: 0 12px;
@@ -47,7 +52,7 @@
       backdrop-filter: blur(20px);
       border: 2px solid transparent;
       border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
-      border-radius: 12px;
+      border-radius: 16px;
       padding: 16px;
       display: flex;
       flex-direction: column;
@@ -156,6 +161,7 @@
       width: var(--field-width);
       border: 2px solid transparent;
       border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
+      border-radius: 12px;
     }
     button {
       flex: 0 0 auto;

--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
       user-select: none;
     }
 
-    body.win32 {
-      border-radius: 12px;
-      overflow: hidden;
-    }
+      html.win32, body.win32 {
+        border-radius: 12px;
+        overflow: hidden;
+      }
     header {
       height: 32px;
       padding: 0 12px;
@@ -161,7 +161,7 @@
       width: var(--field-width);
       border: 2px solid transparent;
       border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
-      border-radius: 12px;
+      border-radius:  12px !important;
     }
     button {
       flex: 0 0 auto;

--- a/main.js
+++ b/main.js
@@ -213,23 +213,26 @@ function createWindow() {
     app.dock.setIcon(icon);
   }
   const WindowClass = isWin ? MicaBrowserWindow : BrowserWindow;
-  win = new WindowClass({
+  const windowOpts = {
     width: 640,
     height: 360,
     icon,
     titleBarStyle: 'hidden',
     titleBarOverlay: { color: '#00000000', symbolColor: '#ffffff' },
     autoHideMenuBar: true,
-    backgroundColor: '#01000000',
     show: false,
     alwaysOnTop: true,
+    ...(isWin
+      ? { frame: false, transparent: true, roundedCorners: true, backgroundColor: '#00000000' }
+      : { backgroundColor: '#01000000' }),
     ...(isMac ? { vibrancy: 'under-window', visualEffectState: 'active' } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false
     }
-  });
+  };
+  win = new WindowClass(windowOpts);
   if (typeof win.setIcon === 'function') {
     win.setIcon(icon);
   }
@@ -239,6 +242,9 @@ function createWindow() {
     if (isWin) {
       win.setDarkTheme();
       win.setMicaEffect();
+      if (typeof win.setRoundedCorners === 'function') {
+        win.setRoundedCorners(true);
+      }
     }
     win.show();
   });

--- a/main.js
+++ b/main.js
@@ -242,11 +242,11 @@ function createWindow() {
     if (isWin) {
       win.setDarkTheme();
       win.setMicaEffect();
-      if (typeof win.setRoundedCorners === 'function') {
-        win.setRoundedCorners(true);
-      }
     }
     win.show();
+    if (isWin && typeof win.setRoundedCorners === 'function') {
+      win.setRoundedCorners(true);
+    }
   });
   win.on('closed', () => {
     win = null;

--- a/main.js
+++ b/main.js
@@ -247,6 +247,12 @@ function createWindow() {
     if (isWin && typeof win.setRoundedCorners === 'function') {
       win.setRoundedCorners(true);
     }
+    // --- Force a tiny resize to trigger Mica ---
+    setTimeout(() => {
+      const [w, h] = win.getSize();
+      win.setSize(w, h + 1);
+      setTimeout(() => win.setSize(w, h), 10);
+    }, 100);
   });
   win.on('closed', () => {
     win = null;
@@ -276,12 +282,12 @@ app.on('will-quit', () => {
   ipcMain.on('set-key-hotkey', (e, accelerator) => registerKeyHotkey(accelerator));
   ipcMain.handle('get-hotkeys', () => ({ clickHotkey, keyHotkey }));
   ipcMain.handle('pick-point', () => pickPoint());
-  ipcMain.on('resize-window', (e, height) => {
-    if (win && !win.isDestroyed()) {
-      const [w] = win.getContentSize();
-      win.setContentSize(w, Math.round(height));
-    }
-  });
+  // ipcMain.on('resize-window', (e, height) => {
+  //   if (win && !win.isDestroyed()) {
+  //     const [w] = win.getContentSize();
+  //     win.setContentSize(w, Math.round(height));
+  //   }
+  // });
 
   ipcMain.on('update-click-config', (e, config) => {
     if (config) {
@@ -290,3 +296,10 @@ app.on('will-quit', () => {
       if (config.target) clickTarget = config.target;
     }
   });
+ipcMain.handle('resize', (event, height) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (win) {
+    const [width] = win.getContentSize();
+    win.setContentSize(width, Math.round(height) + 8);
+  }
+});

--- a/preload.js
+++ b/preload.js
@@ -13,6 +13,6 @@ contextBridge.exposeInMainWorld('auto', {
     onClickerToggled: (callback) => ipcRenderer.on('clicker-toggled', (_, state) => callback(state)),
     onKeyToggled: (callback) => ipcRenderer.on('key-toggled', (_, state) => callback(state)),
     pickPoint: () => ipcRenderer.invoke('pick-point'),
-    resize: (height) => ipcRenderer.send('resize-window', height),
+    resize: (height) => ipcRenderer.invoke('resize', height),
     updateClickConfig: (config) => ipcRenderer.send('update-click-config', config)
   });

--- a/renderer.js
+++ b/renderer.js
@@ -3,6 +3,7 @@ const header = document.querySelector('header');
 const platform = window.env && window.env.platform;
 if (platform) {
   document.body.classList.add(platform);
+  document.documentElement.classList.add(platform);
 }
 if (platform === 'darwin') {
   header.style.justifyContent = 'flex-end';

--- a/renderer.js
+++ b/renderer.js
@@ -63,7 +63,15 @@ keySelect.value = 'a';
 
   clickTargetSel.addEventListener('change', () => {
     coordFields.style.display = clickTargetSel.value === 'coords' ? 'flex' : 'none';
-    resizeToContent();
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (clickTargetSel.value !== 'coords') {
+          window.auto.resize(360); // Force original height
+        } else {
+          resizeToContent();
+        }
+      });
+    });
     sendClickConfig();
   });
 

--- a/renderer.js
+++ b/renderer.js
@@ -33,10 +33,16 @@ keySelect.value = 'a';
   const pickCoordBtn = document.getElementById('pickCoord');
   const clickIntervalInput = document.getElementById('clickInterval');
 
+  let lastHeight = 0;
   function resizeToContent() {
     const h = document.documentElement.scrollHeight;
-    window.auto.resize(h);
+    if (h !== lastHeight) {
+      lastHeight = h;
+      window.auto.resize(h);
+    }
   }
+  const ro = new ResizeObserver(() => resizeToContent());
+  ro.observe(document.querySelector('main'));
 
   function getClickConfig() {
     const interval = parseInt(clickIntervalInput.value, 10);

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,10 @@
 const keySelect = document.getElementById('key');
 const header = document.querySelector('header');
-if (window.env && window.env.platform === 'darwin') {
+const platform = window.env && window.env.platform;
+if (platform) {
+  document.body.classList.add(platform);
+}
+if (platform === 'darwin') {
   header.style.justifyContent = 'flex-end';
 } else {
   header.style.justifyContent = 'flex-start';


### PR DESCRIPTION
## Summary
- Round the Windows app window with a Win32-specific body style
- Add platform class in renderer to apply OS-specific styles
- Increase border radius on auto panes and Start buttons on Windows and macOS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7f62c80c832f8da413c961cc06d9