### PR TITLE
chore: upgrade electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@jitsi/robotjs": "^0.6.17",
-        "electron": "^27.1.0",
+        "electron": "^37.2.6",
         "mica-electron": "^1.5.16"
       },
       "devDependencies": {
@@ -316,12 +316,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.122",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
-      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "version": "22.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
+      "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/responselike": {
@@ -663,14 +663,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.3.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.11.tgz",
-      "integrity": "sha512-E1SiyEoI8iW5LW/MigCr7tJuQe7+0105UjqY7FkmCD12e2O6vtUbQ0j05HaBh2YgvkcEVgvQ2A8suIq5b5m6Gw==",
+      "version": "37.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
+      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -2042,9 +2042,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
-    "electron": "^27.1.0",
+    "electron": "^37.2.6",
     "mica-electron": "^1.5.16",
     "@jitsi/robotjs": "^0.6.17"
   },


### PR DESCRIPTION
## Summary
- upgrade to Electron 37.2.6
- ensure mica-electron remains at 1.5.16

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689adbc68f20832f9c2a34e39efa39fe