### PR TITLE
fix: clear quarantine flag in mac build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you manage versions with `nvm`, the project ships an `.nvmrc` file; run `nvm 
 
 If you encounter the error `Electron failed to install correctly`, remove the `node_modules` folder and rerun `npm install`.
 If Electron logs repeated GPU process crashes, start the app with `AUTOMANCER_DISABLE_GPU=1 npm start` and ensure your GPU drivers are up to date.
+If macOS warns that "AutoMancer is damaged and can't be opened," the `dist:mac` script now removes the quarantine attribute automatically. For an existing copy, run `xattr -cr /Applications/AutoMancer.app` to clear the attribute manually.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "package:mac": "electron-packager . AutoMancer --platform=darwin --arch=x64 --icon=images/AutoMancer.icns --out=dist --overwrite",
     "package": "npm run package:win && npm run package:mac",
     "dist:win": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win",
-    "dist:mac": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac",
+    "dist:mac": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac && xattr -cr dist/mac/AutoMancer.app",
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
@@ -35,7 +35,9 @@
     ],
     "mac": {
       "target": "dmg",
-      "icon": "images/AutoMancer.icns"
+      "icon": "images/AutoMancer.icns",
+      "identity": null,
+      "gatekeeperAssess": false
     },
     "win": {
       "target": "nsis",


### PR DESCRIPTION
## Summary
- clear macOS quarantine flag during `dist:mac` packaging
- disable gatekeeper assessment by default
- document how to handle damaged app warnings on macOS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689afa1d6460832fb264fe9593170b9f