### PR TITLE
Add test coverage for automation controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,7 @@
     </div>
     </section>
   </main>
+  <script src="toAccelerator.js"></script>
   <script src="renderer.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "package": "npm run package:win && npm run package:mac",
     "dist:win": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win",
     "dist:mac": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac && xattr -cr dist/mac-arm64/AutoMancer.app",
-    "test": "echo \"No tests specified\""
+    "test": "node --test"
   },
   "dependencies": {
     "mica-electron": "^1.5.16",

--- a/renderer.js
+++ b/renderer.js
@@ -123,23 +123,6 @@ window.auto.onKeyToggled((state) => {
   toggleKeyBtn.classList.toggle('running', state);
 });
 
-function toAccelerator(e) {
-  const parts = [];
-  if (e.ctrlKey) parts.push('Ctrl');
-  if (e.shiftKey) parts.push('Shift');
-  if (e.altKey) parts.push('Alt');
-  if (e.metaKey) parts.push('Super');
-  let key = e.key;
-  if (key === ' ') key = 'Space';
-  if (key.startsWith('Arrow')) key = key.replace('Arrow', '');
-  if (key.length === 1) key = key.toUpperCase();
-  else key = key[0].toUpperCase() + key.slice(1);
-  if (!['Shift','Control','Alt','Super','Meta','Ctrl'].includes(key)) {
-    parts.push(key);
-  }
-  return parts.join('+');
-}
-
 function captureHotkey(button, setter) {
   const overlay = document.createElement('div');
   overlay.className = 'modal';

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { mock } = require('node:test');
+const { setTimeout: delay } = require('node:timers/promises');
+const Module = require('module');
+
+process.env.NODE_ENV = 'test';
+
+const mouseClick = mock.fn();
+const moveMouse = mock.fn();
+const keyTap = mock.fn();
+
+const originalLoad = Module._load;
+Module._load = (request, parent, isMain) => {
+  if (request === 'electron') {
+    return {
+      app: {
+        disableHardwareAcceleration: () => {},
+        whenReady: () => Promise.resolve(),
+        on: () => {},
+        getPath: () => '.',
+        dock: { setIcon: () => {} }
+      },
+      ipcMain: { on: () => {}, handle: () => {}, once: () => {}, removeListener: () => {} },
+      globalShortcut: { unregister: () => {}, unregisterAll: () => {}, register: () => {} },
+      BrowserWindow: class {},
+      screen: { getAllDisplays: () => [], getCursorScreenPoint: () => ({ x: 0, y: 0 }) },
+      nativeImage: { createFromPath: () => ({}) }
+    };
+  }
+  if (request === 'mica-electron') {
+    return { MicaBrowserWindow: class {} };
+  }
+  if (request === '@jitsi/robotjs') {
+    return { mouseClick, moveMouse, keyTap };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const {
+  startClicker,
+  stopClicker,
+  updateClickConfig,
+  getClickState,
+  startKeyPresser,
+  stopKeyPresser,
+  getKeyState
+} = require('../main.js');
+
+test('auto clicker config and toggling', async () => {
+  const before = mouseClick.mock.calls.length;
+  startClicker({ interval: 1, jitter: 0, button: 'left', target: { type: 'current' } });
+  await delay(5);
+  const after = mouseClick.mock.calls.length;
+  assert.ok(after > before);
+  let state = getClickState();
+  assert.strictEqual(state.interval, 1);
+  assert.strictEqual(state.button, 'left');
+  assert.deepStrictEqual(state.target, { type: 'current' });
+  assert.ok(state.running);
+
+  updateClickConfig({ interval: 5, jitter: 2, button: 'right', target: { type: 'coords', x: 10, y: 20 } });
+  state = getClickState();
+  assert.strictEqual(state.interval, 5);
+  assert.strictEqual(state.jitter, 2);
+  assert.strictEqual(state.button, 'right');
+  assert.deepStrictEqual(state.target, { type: 'coords', x: 10, y: 20 });
+
+  stopClicker();
+  assert.ok(!getClickState().running);
+});
+
+test('auto key presser config and toggling', async () => {
+  const before = keyTap.mock.calls.length;
+  startKeyPresser('x', 1);
+  await delay(5);
+  const after = keyTap.mock.calls.length;
+  assert.ok(after > before);
+  let state = getKeyState();
+  assert.strictEqual(state.key, 'x');
+  assert.strictEqual(state.interval, 1);
+  assert.ok(state.running);
+
+  startKeyPresser('y', 2);
+  state = getKeyState();
+  assert.strictEqual(state.key, 'y');
+  assert.strictEqual(state.interval, 2);
+
+  stopKeyPresser();
+  assert.ok(!getKeyState().running);
+});

--- a/test/toAccelerator.test.js
+++ b/test/toAccelerator.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const toAccelerator = require('../toAccelerator.js');
+
+test('converts simple key', () => {
+  assert.strictEqual(toAccelerator({ key: 'a' }), 'A');
+});
+
+test('converts modifiers with key', () => {
+  const evt = { key: 'a', ctrlKey: true, shiftKey: true };
+  assert.strictEqual(toAccelerator(evt), 'Ctrl+Shift+A');
+});
+
+test('handles special keys', () => {
+  assert.strictEqual(toAccelerator({ key: ' ' }), 'Space');
+  assert.strictEqual(toAccelerator({ key: 'ArrowLeft' }), 'Left');
+});

--- a/toAccelerator.js
+++ b/toAccelerator.js
@@ -1,0 +1,20 @@
+function toAccelerator(e) {
+  const parts = [];
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.shiftKey) parts.push('Shift');
+  if (e.altKey) parts.push('Alt');
+  if (e.metaKey) parts.push('Super');
+  let key = e.key;
+  if (key === ' ') key = 'Space';
+  if (key.startsWith('Arrow')) key = key.replace('Arrow', '');
+  if (key.length === 1) key = key.toUpperCase();
+  else key = key[0].toUpperCase() + key.slice(1);
+  if (!['Shift','Control','Alt','Super','Meta','Ctrl'].includes(key)) {
+    parts.push(key);
+  }
+  return parts.join('+');
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = toAccelerator;
+}


### PR DESCRIPTION
## Summary
- expose clicker and key presser state for testing and guard Electron startup during tests
- add unit tests for clicker/key presser configuration and toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8ae5b108832f8ad53d92736378f5