### PR TITLE
Use electron-builder uninstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ If you manage versions with `nvm`, the project ships an `.nvmrc` file; run `nvm 
    Run the command appropriate for your host OS. DMG installers must be built on macOS.
    Windows builds may require Administrator rights or Developer Mode to allow symlink creation during extraction.
 
+5. Uninstall the app
+   - **Windows:** the NSIS installer creates `Uninstall AutoMancer.exe` in the installation directory and registers it with "Add or Remove Programs".
+     Running it removes the application and its configuration data.
+   - **macOS/Linux:** delete the application bundle and remove the config directory (`~/Library/Application Support/AutoMancer` on macOS or `~/.config/AutoMancer` on Linux).
+
 ## Notes
 
 - Hotkeys toggle the automation globally.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "win": {
       "target": "nsis",
       "icon": "images/AutoMancer.ico"
+    },
+    "nsis": {
+      "uninstallDisplayName": "Uninstall AutoMancer",
+      "deleteAppDataOnUninstall": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- configure electron-builder's NSIS target to remove app data on uninstall
- drop custom Node.js uninstaller script in favor of built-in `Uninstall AutoMancer.exe`
- document platform-specific uninstallation steps

## Testing
- `npm test`
- `npm run dist:win` *(fails: wine is required)*

------
https://chatgpt.com/codex/tasks/task_e_689b95b90f14832fa416e2b525ca437b