### PR TITLE
Add tabbed interface and slim window for AutoMancer

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,13 +70,6 @@
       border-bottom-color: var(--accent);
       color: var(--accent);
     }
-    .tab-content {
-      display: none;
-    }
-    .tab-content.active {
-      display: flex;
-      flex-direction: column;
-    }
     .card {
       backdrop-filter: blur(20px);
       background: var(--bg);
@@ -86,6 +79,12 @@
       padding: 16px;
       display: flex;
       flex-direction: column;
+    }
+    .card.tab-content {
+      display: none;
+    }
+    .card.tab-content.active {
+      display: flex;
     }
     h1, h2 {
       margin: 0 0 12px;

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
       <h2><img src="images/keyboard.png" alt="" class="icon" />Auto Key Presser</h2>
       <label>
         Key
-        <select id="key"></select>
+        <select id="keySelect"></select>
       </label>
       <label>
         Interval (ms)

--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
       user-select: none;
     }
 
-      html.win32, body.win32 {
-        border-radius: 12px;
-        overflow: hidden;
-      }
+    html, body {
+      border-radius: 12px;
+      overflow: hidden;
+    }
     header {
       height: 32px;
       padding: 0 12px;
@@ -63,8 +63,12 @@
       border-radius: 0;
     }
     .tab.active {
-      border-bottom-color: var(--accent);
-      color: var(--accent);
+      border-bottom: 2px solid transparent;
+      border-image: linear-gradient(to bottom right, #D33818, #8c5cf3) 1;
+      background: linear-gradient(to bottom right, #D33818, #8c5cf3);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
     }
     .card {
       backdrop-filter: blur(20px);

--- a/index.html
+++ b/index.html
@@ -18,14 +18,25 @@
       padding: 0;
       font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
       color: #fff;
-      /* Slight tint so clicks outside cards don't fall through */
-      background: rgba(0, 0, 0, 0.01);
+      background: transparent;
       user-select: none;
+      position: relative;
     }
 
     html, body {
       border-radius: 12px;
       overflow: hidden;
+    }
+
+    /* Provide a barely visible backdrop so transparent areas still
+       capture clicks while allowing rounded corners to show. */
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.01);
+      border-radius: 12px;
+      pointer-events: none;
     }
     header {
       height: 32px;

--- a/index.html
+++ b/index.html
@@ -53,19 +53,22 @@
     }
     .tabs {
       display: flex;
-      gap: 8px;
       -webkit-app-region: no-drag;
+      border-bottom: 1px solid var(--border);
     }
-    .tab-btn {
+    .tab {
       flex: 1;
-      padding: 8px 0;
-      background: rgba(255, 255, 255, 0.07);
-      border: 1px solid var(--border);
-      border-radius: 6px;
+      padding: 6px 0;
+      background: none;
+      border: none;
+      color: inherit;
       cursor: pointer;
+      border-bottom: 2px solid transparent;
+      border-radius: 0;
     }
-    .tab-btn.active {
-      border-color: var(--accent);
+    .tab.active {
+      border-bottom-color: var(--accent);
+      color: var(--accent);
     }
     .tab-content {
       display: none;
@@ -238,9 +241,9 @@
 <body>
   <header><img src="images/AutoMancer.png" alt="AutoMancer logo" />AutoMancer</header>
   <main>
-    <div class="tabs">
-      <button class="tab-btn active" data-tab="clicker">Auto Clicker</button>
-      <button class="tab-btn" data-tab="key">Auto Key Presser</button>
+    <div class="tabs" role="tablist">
+      <button class="tab active" data-tab="clicker" role="tab">Auto Clicker</button>
+      <button class="tab" data-tab="key" role="tab">Auto Key Presser</button>
     </div>
     <section id="clicker" class="card tab-content active">
       <h2><img src="images/cursor.png" alt="" class="icon" />Auto Clicker</h2>

--- a/index.html
+++ b/index.html
@@ -23,10 +23,6 @@
       user-select: none;
     }
 
-    html, body {
-      height: 100%;
-    }
-
       html.win32, body.win32 {
         border-radius: 12px;
         overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -45,11 +45,34 @@
     }
     main {
       padding: 16px 24px 24px;
-      display: grid;
+      display: flex;
+      flex-direction: column;
       gap: 16px;
-      grid-template-columns: repeat(2, 1fr);
       align-items: stretch;
       box-sizing: border-box;
+    }
+    .tabs {
+      display: flex;
+      gap: 8px;
+      -webkit-app-region: no-drag;
+    }
+    .tab-btn {
+      flex: 1;
+      padding: 8px 0;
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    .tab-btn.active {
+      border-color: var(--accent);
+    }
+    .tab-content {
+      display: none;
+    }
+    .tab-content.active {
+      display: flex;
+      flex-direction: column;
     }
     .card {
       backdrop-filter: blur(20px);
@@ -215,7 +238,11 @@
 <body>
   <header><img src="images/AutoMancer.png" alt="AutoMancer logo" />AutoMancer</header>
   <main>
-    <section class="card">
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="clicker">Auto Clicker</button>
+      <button class="tab-btn" data-tab="key">Auto Key Presser</button>
+    </div>
+    <section id="clicker" class="card tab-content active">
       <h2><img src="images/cursor.png" alt="" class="icon" />Auto Clicker</h2>
       <label>
         Interval (ms)
@@ -251,7 +278,7 @@
         <button id="toggleClicker">Start</button>
       </div>
     </section>
-    <section class="card">
+    <section id="key" class="card tab-content">
       <h2><img src="images/keyboard.png" alt="" class="icon" />Auto Key Presser</h2>
       <label>
         Key

--- a/main.js
+++ b/main.js
@@ -125,6 +125,13 @@ function updateClickConfig(config) {
   }
 }
 
+function updateKeyConfig(config) {
+  if (config) {
+    if (typeof config.key === 'string') currentKey = config.key;
+    if (Number.isFinite(config.interval)) keyInterval = config.interval;
+  }
+}
+
 function getClickState() {
   return {
     interval: clickInterval,
@@ -412,6 +419,9 @@ if (process.env.NODE_ENV !== 'test') {
   ipcMain.on('update-click-config', (e, config) => {
     updateClickConfig(config);
   });
+  ipcMain.on('update-key-config', (e, config) => {
+    updateKeyConfig(config);
+  });
   ipcMain.on('resize-window', (e, height) => {
     if (win) {
       const [w] = win.getContentSize();
@@ -425,6 +435,7 @@ module.exports = {
   startKeyPresser,
   stopKeyPresser,
   updateClickConfig,
+  updateKeyConfig,
   getClickState,
   getKeyState
 };

--- a/main.js
+++ b/main.js
@@ -183,6 +183,7 @@ function pickPoint() {
       skipTaskbar: true,
       backgroundColor: '#00000000',
       hasShadow: false,
+      acceptFirstMouse: true,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false
@@ -191,7 +192,10 @@ function pickPoint() {
     picker.loadFile(path.join(__dirname, 'picker.html'), {
       query: { offsetX: minX, offsetY: minY }
     });
-    picker.once('ready-to-show', () => picker.show());
+    picker.once('ready-to-show', () => {
+      picker.show();
+      picker.focus();
+    });
 
     const finish = () => {
       const pos = screen.getCursorScreenPoint();
@@ -247,7 +251,7 @@ function createWindow() {
   const WindowClass = isWin ? MicaBrowserWindow : BrowserWindow;
   const windowOpts = {
     width: 360,
-    height: 420,
+    height: 360,
     resizable: false,
     icon,
     titleBarStyle: 'hidden',
@@ -369,6 +373,12 @@ if (process.env.NODE_ENV !== 'test') {
   ipcMain.handle('pick-point', () => pickPoint());
   ipcMain.on('update-click-config', (e, config) => {
     updateClickConfig(config);
+  });
+  ipcMain.on('resize-window', (e, height) => {
+    if (win) {
+      const [w] = win.getContentSize();
+      win.setContentSize(w, Math.round(height));
+    }
   });
 
 module.exports = {

--- a/main.js
+++ b/main.js
@@ -180,30 +180,33 @@ function createPickerWindow() {
   });
 }
 
-function pickPoint() {
-  return new Promise((resolve) => {
-    createPickerWindow();
-    const displays = screen.getAllDisplays();
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-    for (const d of displays) {
-      const b = d.bounds;
-      minX = Math.min(minX, b.x);
-      minY = Math.min(minY, b.y);
-      maxX = Math.max(maxX, b.x + b.width);
-      maxY = Math.max(maxY, b.y + b.height);
-    }
-    pickerWin.setBounds({
-      x: minX,
-      y: minY,
-      width: maxX - minX,
-      height: maxY - minY
-    });
-    pickerWin.show();
-    pickerWin.focus();
+async function pickPoint() {
+  createPickerWindow();
+  if (pickerWin.webContents.isLoading()) {
+    await new Promise(resolve => pickerWin.webContents.once('did-finish-load', resolve));
+  }
+  const displays = screen.getAllDisplays();
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const d of displays) {
+    const b = d.bounds;
+    minX = Math.min(minX, b.x);
+    minY = Math.min(minY, b.y);
+    maxX = Math.max(maxX, b.x + b.width);
+    maxY = Math.max(maxY, b.y + b.height);
+  }
+  pickerWin.setBounds({
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY
+  });
+  pickerWin.show();
+  pickerWin.focus();
 
+  return new Promise((resolve) => {
     const finish = () => {
       const pos = screen.getCursorScreenPoint();
       resolve(pos);

--- a/main.js
+++ b/main.js
@@ -248,6 +248,7 @@ function createWindow() {
   const windowOpts = {
     width: 360,
     height: 360,
+    resizable: false,
     icon,
     titleBarStyle: 'hidden',
     titleBarOverlay: { color: '#00000000', symbolColor: '#ffffff' },
@@ -366,23 +367,9 @@ if (process.env.NODE_ENV !== 'test') {
   ipcMain.on('set-key-hotkey', (e, accelerator) => registerKeyHotkey(accelerator));
   ipcMain.handle('get-hotkeys', () => ({ clickHotkey, keyHotkey }));
   ipcMain.handle('pick-point', () => pickPoint());
-  // ipcMain.on('resize-window', (e, height) => {
-  //   if (win && !win.isDestroyed()) {
-  //     const [w] = win.getContentSize();
-  //     win.setContentSize(w, Math.round(height));
-  //   }
-  // });
-
   ipcMain.on('update-click-config', (e, config) => {
     updateClickConfig(config);
   });
-ipcMain.handle('resize', (event, height) => {
-  const win = BrowserWindow.fromWebContents(event.sender);
-  if (win) {
-    const [width] = win.getContentSize();
-    win.setContentSize(width, Math.round(height) + 8);
-  }
-});
 
 module.exports = {
   startClicker,

--- a/main.js
+++ b/main.js
@@ -246,7 +246,7 @@ function createWindow() {
   }
   const WindowClass = isWin ? MicaBrowserWindow : BrowserWindow;
   const windowOpts = {
-    width: 640,
+    width: 360,
     height: 360,
     icon,
     titleBarStyle: 'hidden',

--- a/main.js
+++ b/main.js
@@ -290,6 +290,9 @@ function createWindow() {
   if (typeof win.setIcon === 'function') {
     win.setIcon(icon);
   }
+  if (typeof win.setRoundedCorners === 'function') {
+    win.setRoundedCorners(true);
+  }
 
   win.loadFile(path.join(__dirname, 'index.html'));
   win.once('ready-to-show', () => {
@@ -298,7 +301,7 @@ function createWindow() {
       win.setMicaEffect();
     }
     win.show();
-    if (isWin && typeof win.setRoundedCorners === 'function') {
+    if (typeof win.setRoundedCorners === 'function') {
       win.setRoundedCorners(true);
     }
     // --- Force a tiny resize to trigger Mica ---

--- a/main.js
+++ b/main.js
@@ -178,7 +178,7 @@ function pickPoint() {
       height: maxY - minY,
       transparent: true,
       frame: false,
-      show: false,
+      show: true,
       alwaysOnTop: true,
       skipTaskbar: true,
       backgroundColor: '#00000000',
@@ -189,12 +189,11 @@ function pickPoint() {
         contextIsolation: false
       }
     });
+    picker.webContents.once('dom-ready', () => {
+      picker.focus();
+    });
     picker.loadFile(path.join(__dirname, 'picker.html'), {
       query: { offsetX: minX, offsetY: minY }
-    });
-    picker.once('ready-to-show', () => {
-      picker.show();
-      picker.focus();
     });
 
     const finish = () => {

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const { MicaBrowserWindow } = require('mica-electron');
 let robot;
 let win;
 let pickerWin;
+let isQuitting = false;
 
 // Disable GPU acceleration by default to avoid crashes on some systems.
 // Set AUTOMANCER_ENABLE_GPU=1 to opt in to hardware acceleration.
@@ -177,6 +178,10 @@ function createPickerWindow() {
   pickerWin.loadFile(path.join(__dirname, 'picker.html'));
   pickerWin.on('closed', () => {
     pickerWin = null;
+    // Preload a fresh picker for next use to avoid load delays
+    if (!isQuitting) {
+      createPickerWindow();
+    }
   });
 }
 
@@ -211,6 +216,7 @@ async function pickPoint() {
       const pos = screen.getCursorScreenPoint();
       resolve(pos);
       pickerWin.hide();
+      pickerWin.close();
     };
 
     ipcMain.once('picker-done', finish);
@@ -371,6 +377,9 @@ if (process.env.NODE_ENV !== 'test') {
     globalShortcut.unregisterAll();
     stopClicker();
     stopKeyPresser();
+  });
+  app.on('before-quit', () => {
+    isQuitting = true;
   });
 }
 

--- a/main.js
+++ b/main.js
@@ -247,7 +247,7 @@ function createWindow() {
   const WindowClass = isWin ? MicaBrowserWindow : BrowserWindow;
   const windowOpts = {
     width: 360,
-    height: 360,
+    height: 420,
     resizable: false,
     icon,
     titleBarStyle: 'hidden',

--- a/preload.js
+++ b/preload.js
@@ -14,5 +14,6 @@ contextBridge.exposeInMainWorld('auto', {
     onKeyToggled: (callback) => ipcRenderer.on('key-toggled', (_, state) => callback(state)),
     pickPoint: () => ipcRenderer.invoke('pick-point'),
     updateClickConfig: (config) => ipcRenderer.send('update-click-config', config),
+    updateKeyConfig: (config) => ipcRenderer.send('update-key-config', config),
     resizeWindow: (height) => ipcRenderer.send('resize-window', height)
   });

--- a/preload.js
+++ b/preload.js
@@ -13,5 +13,6 @@ contextBridge.exposeInMainWorld('auto', {
     onClickerToggled: (callback) => ipcRenderer.on('clicker-toggled', (_, state) => callback(state)),
     onKeyToggled: (callback) => ipcRenderer.on('key-toggled', (_, state) => callback(state)),
     pickPoint: () => ipcRenderer.invoke('pick-point'),
-    updateClickConfig: (config) => ipcRenderer.send('update-click-config', config)
+    updateClickConfig: (config) => ipcRenderer.send('update-click-config', config),
+    resizeWindow: (height) => ipcRenderer.send('resize-window', height)
   });

--- a/preload.js
+++ b/preload.js
@@ -13,6 +13,5 @@ contextBridge.exposeInMainWorld('auto', {
     onClickerToggled: (callback) => ipcRenderer.on('clicker-toggled', (_, state) => callback(state)),
     onKeyToggled: (callback) => ipcRenderer.on('key-toggled', (_, state) => callback(state)),
     pickPoint: () => ipcRenderer.invoke('pick-point'),
-    resize: (height) => ipcRenderer.invoke('resize', height),
     updateClickConfig: (config) => ipcRenderer.send('update-click-config', config)
   });

--- a/renderer.js
+++ b/renderer.js
@@ -36,12 +36,17 @@ keySelect.value = 'a';
 
   const tabButtons = document.querySelectorAll('.tab');
   const tabs = document.querySelectorAll('.tab-content');
+  function resizeToContent() {
+    const height = Math.ceil(document.documentElement.scrollHeight);
+    window.auto.resizeWindow(height);
+  }
   tabButtons.forEach(btn => {
     btn.addEventListener('click', () => {
       tabButtons.forEach(b => b.classList.remove('active'));
       tabs.forEach(t => t.classList.remove('active'));
       btn.classList.add('active');
       document.getElementById(btn.dataset.tab).classList.add('active');
+      resizeToContent();
     });
   });
 
@@ -66,6 +71,7 @@ keySelect.value = 'a';
 
   clickTargetSel.addEventListener('change', () => {
     coordFields.style.display = clickTargetSel.value === 'coords' ? 'flex' : 'none';
+    resizeToContent();
     sendClickConfig();
   });
 
@@ -152,3 +158,4 @@ window.auto.getHotkeys().then(({ clickHotkey, keyHotkey }) => {
 });
 
 sendClickConfig();
+resizeToContent();

--- a/renderer.js
+++ b/renderer.js
@@ -36,9 +36,10 @@ keySelect.value = 'a';
 
   const tabButtons = document.querySelectorAll('.tab');
   const tabs = document.querySelectorAll('.tab-content');
+  const main = document.querySelector('main');
   function resizeToContent() {
-    const height = Math.ceil(document.documentElement.scrollHeight);
-    window.auto.resizeWindow(height);
+    const contentHeight = header.offsetHeight + main.scrollHeight;
+    window.auto.resizeWindow(Math.ceil(contentHeight));
   }
   tabButtons.forEach(btn => {
     btn.addEventListener('click', () => {

--- a/renderer.js
+++ b/renderer.js
@@ -45,6 +45,18 @@ keySelect.value = 'a';
   const ro = new ResizeObserver(() => resizeToContent());
   ro.observe(document.querySelector('main'));
 
+  const tabButtons = document.querySelectorAll('.tab-btn');
+  const tabs = document.querySelectorAll('.tab-content');
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      tabButtons.forEach(b => b.classList.remove('active'));
+      tabs.forEach(t => t.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.tab).classList.add('active');
+      resizeToContent();
+    });
+  });
+
   function getClickConfig() {
     const interval = parseInt(clickIntervalInput.value, 10);
     const jitter = parseInt(clickJitterInput.value, 10);

--- a/renderer.js
+++ b/renderer.js
@@ -1,4 +1,4 @@
-const keySelect = document.getElementById('key');
+const keySelect = document.getElementById('keySelect');
 const header = document.querySelector('header');
 const platform = window.env && window.env.platform;
 if (platform) {
@@ -98,7 +98,7 @@ toggleKeyBtn.addEventListener('click', () => {
   if (running) {
     window.auto.stopKeyPresser();
   } else {
-    const key = document.getElementById('key').value;
+    const key = keySelect.value;
     const interval = parseInt(document.getElementById('keyInterval').value, 10);
     window.auto.startKeyPresser(key, interval);
   }

--- a/renderer.js
+++ b/renderer.js
@@ -45,7 +45,7 @@ keySelect.value = 'a';
   const ro = new ResizeObserver(() => resizeToContent());
   ro.observe(document.querySelector('main'));
 
-  const tabButtons = document.querySelectorAll('.tab-btn');
+  const tabButtons = document.querySelectorAll('.tab');
   const tabs = document.querySelectorAll('.tab-content');
   tabButtons.forEach(btn => {
     btn.addEventListener('click', () => {

--- a/renderer.js
+++ b/renderer.js
@@ -34,17 +34,6 @@ keySelect.value = 'a';
   const clickIntervalInput = document.getElementById('clickInterval');
   const clickJitterInput = document.getElementById('clickJitter');
 
-  let lastHeight = 0;
-  function resizeToContent() {
-    const h = document.documentElement.scrollHeight;
-    if (h !== lastHeight) {
-      lastHeight = h;
-      window.auto.resize(h);
-    }
-  }
-  const ro = new ResizeObserver(() => resizeToContent());
-  ro.observe(document.querySelector('main'));
-
   const tabButtons = document.querySelectorAll('.tab');
   const tabs = document.querySelectorAll('.tab-content');
   tabButtons.forEach(btn => {
@@ -53,7 +42,6 @@ keySelect.value = 'a';
       tabs.forEach(t => t.classList.remove('active'));
       btn.classList.add('active');
       document.getElementById(btn.dataset.tab).classList.add('active');
-      resizeToContent();
     });
   });
 
@@ -78,15 +66,6 @@ keySelect.value = 'a';
 
   clickTargetSel.addEventListener('change', () => {
     coordFields.style.display = clickTargetSel.value === 'coords' ? 'flex' : 'none';
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (clickTargetSel.value !== 'coords') {
-          window.auto.resize(360); // Force original height
-        } else {
-          resizeToContent();
-        }
-      });
-    });
     sendClickConfig();
   });
 
@@ -170,7 +149,6 @@ keyHotkeyBtn.addEventListener('click', () => captureHotkey(keyHotkeyBtn, window.
 window.auto.getHotkeys().then(({ clickHotkey, keyHotkey }) => {
   if (clickHotkey) clickHotkeyBtn.textContent = clickHotkey;
   if (keyHotkey) keyHotkeyBtn.textContent = keyHotkey;
-  resizeToContent();
 });
 
 sendClickConfig();

--- a/renderer.js
+++ b/renderer.js
@@ -1,4 +1,5 @@
 const keySelect = document.getElementById('keySelect');
+const keyIntervalInput = document.getElementById('keyInterval');
 const header = document.querySelector('header');
 const platform = window.env && window.env.platform;
 if (platform) {
@@ -99,6 +100,16 @@ keySelect.value = 'a';
     }
   });
 
+  function sendKeyConfig() {
+    window.auto.updateKeyConfig({
+      key: keySelect.value,
+      interval: parseInt(keyIntervalInput.value, 10)
+    });
+  }
+  [keySelect, keyIntervalInput].forEach(el => {
+    el.addEventListener('change', sendKeyConfig);
+  });
+
 const toggleKeyBtn = document.getElementById('toggleKey');
 toggleKeyBtn.addEventListener('click', () => {
   const running = toggleKeyBtn.classList.contains('running');
@@ -106,7 +117,7 @@ toggleKeyBtn.addEventListener('click', () => {
     window.auto.stopKeyPresser();
   } else {
     const key = keySelect.value;
-    const interval = parseInt(document.getElementById('keyInterval').value, 10);
+    const interval = parseInt(keyIntervalInput.value, 10);
     window.auto.startKeyPresser(key, interval);
   }
 });
@@ -159,4 +170,5 @@ window.auto.getHotkeys().then(({ clickHotkey, keyHotkey }) => {
 });
 
 sendClickConfig();
+sendKeyConfig();
 resizeToContent();

--- a/test/auto.test.js
+++ b/test/auto.test.js
@@ -44,7 +44,8 @@ const {
   getClickState,
   startKeyPresser,
   stopKeyPresser,
-  getKeyState
+  getKeyState,
+  updateKeyConfig
 } = require('../main.js');
 
 test('auto clicker config and toggling', async () => {
@@ -80,8 +81,10 @@ test('auto key presser config and toggling', async () => {
   assert.strictEqual(state.key, 'x');
   assert.strictEqual(state.interval, 1);
   assert.ok(state.running);
+  stopKeyPresser();
 
-  startKeyPresser('y', 2);
+  updateKeyConfig({ key: 'y', interval: 2 });
+  startKeyPresser();
   state = getKeyState();
   assert.strictEqual(state.key, 'y');
   assert.strictEqual(state.interval, 2);


### PR DESCRIPTION
## Summary
- Introduce tab navigation that switches between auto clicker and key presser views
- Implement tab logic in renderer and adjust styles for single-column layout
- Reduce default window width for a more compact UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae90e836b4832f83804ffca7f8beee